### PR TITLE
[3D] add stereoscopic depths definitions where missing

### DIFF
--- a/1080i/DialogFullScreenInfo.xml
+++ b/1080i/DialogFullScreenInfo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<depth>DepthOSD</depth>
 	<defaultcontrol always="true">5553</defaultcontrol>
 	<controls>
 		<control type="button" id="22001">
@@ -17,6 +18,7 @@
 			<visible>!Window.IsVisible(playerprocessinfo)</visible>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<control type="image">
+				<depth>DepthOSD+</depth>
 				<left>10</left>
 				<top>-490</top>
 				<width>400</width>

--- a/1080i/DialogMusicInfo.xml
+++ b/1080i/DialogMusicInfo.xml
@@ -19,6 +19,7 @@
 				<bordersize>20</bordersize>
 			</control>
 			<control type="image">
+				<depth>DepthContentPopout</depth>
 				<left>24</left>
 				<top>24</top>
 				<width>567</width>

--- a/1080i/DialogPVRChannelsOSD.xml
+++ b/1080i/DialogPVRChannelsOSD.xml
@@ -5,11 +5,12 @@
 		<control type="group">
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<control type="group">
+				<depth>DepthOSD</depth>
 				<include>OpenClose_Left</include>
 				<control type="image">
-					<left>-20</left>
+					<left>-40</left>
 					<top>-20</top>
-					<width>921</width>
+					<width>941</width>
 					<height>1120</height>
 					<texture>lists/panel.png</texture>
 					<bordertexture border="20">overlays/shadow.png</bordertexture>
@@ -179,6 +180,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthOSD</depth>
 				<include>Animation_TopSlide</include>
 				<control type="image">
 					<left>0</left>

--- a/1080i/DialogPVRGuideOSD.xml
+++ b/1080i/DialogPVRGuideOSD.xml
@@ -7,13 +7,14 @@
 	</coordinates>
 	<controls>
 		<control type="group">
+			<depth>DepthOSD</depth>
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<control type="group">
 				<include>OpenClose_Left</include>
 				<control type="image">
-					<left>-20</left>
+					<left>-40</left>
 					<top>-20</top>
-					<width>820</width>
+					<width>840</width>
 					<height>1120</height>
 					<texture>lists/panel.png</texture>
 					<bordertexture border="20">overlays/shadow.png</bordertexture>

--- a/1080i/DialogPictureInfo.xml
+++ b/1080i/DialogPictureInfo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window>
+	<depth>DepthOSD</depth>
 	<defaultcontrol always="true">9000</defaultcontrol>
 	<onload>SetProperty(infobackground,$INFO[ListItem.FolderPath],home)</onload>
 	<onunload>ClearProperty(infobackground,home)</onunload>

--- a/1080i/DialogPlayerProcessInfo.xml
+++ b/1080i/DialogPlayerProcessInfo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<depth>DepthOSD</depth>
 	<defaultcontrol always="true">5550</defaultcontrol>
 	<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -8,8 +8,8 @@
 		<control type="group">
 			<top>890</top>
 			<control type="image">
-				<left>0</left>
-				<width>110%</width>
+				<left>-40</left>
+				<width>120%</width>
 				<height>200</height>
 				<texture flipy="true">frame/osdfade.png</texture>
 			</control>

--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -20,6 +20,7 @@
 					<bordersize>20</bordersize>
 				</control>
 				<control type="image">
+					<depth>DepthContentPopout</depth>
 					<left>4</left>
 					<top>4</top>
 					<width>526</width>

--- a/1080i/EventLog.xml
+++ b/1080i/EventLog.xml
@@ -118,74 +118,77 @@
 					</focusedlayout>
 				</control>
 			</control>
-			<control type="image">
-				<include>OpenClose_Left</include>
-				<left>-20</left>
-				<top>-20</top>
-				<width>527</width>
-				<height>1120</height>
-				<texture>lists/panel.png</texture>
-				<bordertexture border="20">overlays/shadow.png</bordertexture>
-				<bordersize>20</bordersize>
-			</control>
-			<control type="grouplist" id="9000">
-				<include>OpenClose_Left</include>
-				<orientation>vertical</orientation>
-				<itemgap>-8.5</itemgap>
-				<left>0</left>
-				<top>162</top>
-				<onup>9000</onup>
-				<ondown>9000</ondown>
-				<onleft>50</onleft>
-				<onright>50</onright>
-				<usecontrolcoords>true</usecontrolcoords>
-				<control type="togglebutton" id="4">
-					<width>487</width>
-					<height>110</height>
-					<align>left</align>
-					<aligny>top</aligny>
-					<font>font13</font>
-					<textoffsetx>40</textoffsetx>
-					<texturenofocus></texturenofocus>
-					<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
-					<alttexturenofocus></alttexturenofocus>
-					<alttexturefocus colordiffuse="button_focus">lists/focus.png</alttexturefocus>
-					<textwidth>300</textwidth>
-					<textoffsety>35</textoffsety>
-					<label>$LOCALIZE[31032]: $LOCALIZE[584]</label>
-					<altlabel>$LOCALIZE[31032]: $LOCALIZE[585]</altlabel>
-				</control>
-				<include content="PlaylistWindowButton">
-					<param name="control_id" value="21" />
-					<param name="onclick" value="" />
-					<param name="label" value="" />
-				</include>
-				<control type="radiobutton" id="22">
-					<width>487</width>
-					<height>110</height>
-					<align>left</align>
-					<aligny>top</aligny>
-					<font>font13</font>
-					<texturenofocus></texturenofocus>
-					<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
-					<textoffsetx>40</textoffsetx>
-					<textoffsety>35</textoffsety>
-					<textwidth>300</textwidth>
-				</control>
-				<include content="PlaylistWindowButton">
-					<param name="control_id" value="20" />
-					<param name="onclick" value="" />
-					<param name="label" value="$LOCALIZE[192]" />
-				</include>
+			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<control type="image">
-					<left>40</left>
-					<top>0</top>
-					<width>340</width>
-					<height>360</height>
-					<aspectratio aligny="bottom">keep</aspectratio>
-					<texture fallback="DefaultVideo.png">$INFO[ListItem.Icon]</texture>
+					<include>OpenClose_Left</include>
+					<left>-20</left>
+					<top>-20</top>
+					<width>527</width>
+					<height>1120</height>
+					<texture>lists/panel.png</texture>
 					<bordertexture border="20">overlays/shadow.png</bordertexture>
 					<bordersize>20</bordersize>
+				</control>
+				<control type="grouplist" id="9000">
+					<include>OpenClose_Left</include>
+					<orientation>vertical</orientation>
+					<itemgap>-8.5</itemgap>
+					<left>0</left>
+					<top>162</top>
+					<onup>9000</onup>
+					<ondown>9000</ondown>
+					<onleft>50</onleft>
+					<onright>50</onright>
+					<usecontrolcoords>true</usecontrolcoords>
+					<control type="togglebutton" id="4">
+						<width>487</width>
+						<height>110</height>
+						<align>left</align>
+						<aligny>top</aligny>
+						<font>font13</font>
+						<textoffsetx>40</textoffsetx>
+						<texturenofocus></texturenofocus>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<alttexturenofocus></alttexturenofocus>
+						<alttexturefocus colordiffuse="button_focus">lists/focus.png</alttexturefocus>
+						<textwidth>300</textwidth>
+						<textoffsety>35</textoffsety>
+						<label>$LOCALIZE[31032]: $LOCALIZE[584]</label>
+						<altlabel>$LOCALIZE[31032]: $LOCALIZE[585]</altlabel>
+					</control>
+					<include content="PlaylistWindowButton">
+						<param name="control_id" value="21" />
+						<param name="onclick" value="" />
+						<param name="label" value="" />
+					</include>
+					<control type="radiobutton" id="22">
+						<width>487</width>
+						<height>110</height>
+						<align>left</align>
+						<aligny>top</aligny>
+						<font>font13</font>
+						<texturenofocus></texturenofocus>
+						<texturefocus colordiffuse="button_focus">lists/focus.png</texturefocus>
+						<textoffsetx>40</textoffsetx>
+						<textoffsety>35</textoffsety>
+						<textwidth>300</textwidth>
+					</control>
+					<include content="PlaylistWindowButton">
+						<param name="control_id" value="20" />
+						<param name="onclick" value="" />
+						<param name="label" value="$LOCALIZE[192]" />
+					</include>
+					<control type="image">
+						<left>40</left>
+						<top>0</top>
+						<width>340</width>
+						<height>360</height>
+						<aspectratio aligny="bottom">keep</aspectratio>
+						<texture fallback="DefaultVideo.png">$INFO[ListItem.Icon]</texture>
+						<bordertexture border="20">overlays/shadow.png</bordertexture>
+						<bordersize>20</bordersize>
+					</control>
 				</control>
 			</control>
 			<control type="scrollbar" id="60">

--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -660,6 +660,7 @@
 								</itemlayout>
 								<focusedlayout width="340" height="361">
 									<control type="group">
+										<depth>DepthContentPopout</depth>
 										<top>130</top>
 										<animation effect="zoom" start="100" end="105" time="200" tween="sine" easing="inout" center="170,320">Focus</animation>
 										<animation effect="zoom" start="105" end="100" time="200" tween="sine" easing="inout" center="170,320">UnFocus</animation>
@@ -913,6 +914,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Left</include>
 				<control type="image">
 					<left>-20</left>
@@ -1138,6 +1140,7 @@
 				<param name="breadcrumbs_label" value="" />
 			</include>
 			<control type="group">
+				<depth>DepthBars</depth>
 				<animation effect="slide" end="0,-90" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
 				<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -23,6 +23,7 @@
 	<constant name="DepthOSD">0.40</constant>
 	<constant name="DepthOSD+">0.44</constant>
 	<constant name="DepthContentPopout">0.10</constant>
+	<constant name="DepthContentPanel">0.05</constant>
 	<constant name="DepthBars">0.12</constant>
 	<constant name="DepthBackground">-0.80</constant>
 	<constant name="DepthSideBlade">0.10</constant>

--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window>
 	<defaultcontrol always="true">602</defaultcontrol>
+	<depth>DepthOSD</depth>
 	<controls>
 		<control type="button" id="22001">
 			<description>background close area</description>

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -284,6 +284,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<left>1050</left>
 				<top>182</top>
 				<include>OpenClose_Right</include>

--- a/1080i/MyPVRGuide.xml
+++ b/1080i/MyPVRGuide.xml
@@ -15,156 +15,159 @@
 				<include>Visible_Right</include>
 				<top>140</top>
 				<left>0</left>
-				<control type="image">
-					<left>-20</left>
-					<top>-20</top>
-					<width>1980</width>
-					<height>644</height>
-					<texture border="22">dialogs/dialog-bg.png</texture>
-				</control>
-				<control type="epggrid" id="10">
-					<left>0</left>
-					<top>0</top>
-					<width>1900</width>
-					<height>600</height>
-					<pagecontrol>60</pagecontrol>
-					<scrolltime tween="quadratic" easing="out">200</scrolltime>
-					<timeblocks>34</timeblocks>
-					<rulerunit>6</rulerunit>
-					<onleft>9000</onleft>
-					<onright>60</onright>
-					<onup>10</onup>
-					<ondown>10</ondown>
-					<viewtype label="19032">list</viewtype>
-					<progresstexture border="0,60,18,14" colordiffuse="button_focus">windows/pvr/epg_progress.png</progresstexture>
-					<rulerlayout height="45" width="1400">
-						<control type="label">
-							<width>365</width>
-							<height>45</height>
-							<font>font12</font>
-							<label>$INFO[ListItem.Label]</label>
-							<textoffsetx>10</textoffsetx>
-							<textcolor>button_focus</textcolor>
-						</control>
-					</rulerlayout>
-					<channellayout height="62" width="350">
-						<control type="label">
-							<left>2</left>
-							<top>-2</top>
-							<width>70</width>
-							<height>60</height>
-							<font>font36_title</font>
-							<label>$INFO[ListItem.ChannelNumber]</label>
-							<align>center</align>
-							<aligny>center</aligny>
-						</control>
-						<control type="label" id="1">
-							<left>65</left>
-							<top>-2</top>
-							<width>350</width>
-							<height>60</height>
-							<font>font12</font>
-							<label>$INFO[ListItem.ChannelName]</label>
-							<aligny>center</aligny>
-							<textoffsetx>10</textoffsetx>
-						</control>
-					</channellayout>
-					<focusedchannellayout height="62" width="350">
-						<control type="label">
-							<left>2</left>
-							<top>-2</top>
-							<width>70</width>
-							<height>60</height>
-							<font>font36_title</font>
-							<label>$INFO[ListItem.ChannelNumber]</label>
-							<textcolor>button_focus</textcolor>
-							<align>center</align>
-							<aligny>center</aligny>
-						</control>
-						<control type="label" id="1">
-							<left>65</left>
-							<top>-2</top>
-							<width>350</width>
-							<height>60</height>
-							<font>font12</font>
-							<label>$INFO[ListItem.ChannelName]</label>
-							<textcolor>button_focus</textcolor>
-							<aligny>center</aligny>
-							<textoffsetx>10</textoffsetx>
-						</control>
-					</focusedchannellayout>
-					<itemlayout height="62" width="60">
-						<control type="image" id="2">
-							<width>58</width>
-							<height>58</height>
-							<texture border="3" fallback="windows/pvr/epg-genres/0.png">$INFO[ListItem.Property(GenreType),windows/pvr/epg-genres/,.png]</texture>
-						</control>
-						<control type="label" id="1">
-							<left>6</left>
-							<top>0</top>
-							<width>50</width>
-							<height>36</height>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="image">
-							<left>6</left>
-							<top>35</top>
-							<width>20</width>
-							<height>20</height>
-							<texture>$VAR[PVRTimerIcon]</texture>
-						</control>
-					</itemlayout>
-					<focusedlayout height="62" width="60">
-						<control type="image" id="2">
-							<top>2</top>
-							<left>2</left>
-							<width>54</width>
-							<height>54</height>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.HasFocus(10)</visible>
-						</control>
-						<control type="image" id="2">
-							<width>58</width>
-							<height>58</height>
-							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
-						</control>
-						<control type="image" id="2">
-							<width>58</width>
-							<height>58</height>
-							<top>0</top>
-							<texture border="3" fallback="windows/pvr/epg-genres/0.png">$INFO[ListItem.Property(GenreType),windows/pvr/epg-genres/,.png]</texture>
-							<visible>!Control.HasFocus(10)</visible>
-						</control>
-						<control type="label" id="1">
-							<left>6</left>
-							<top>0</top>
-							<width>50</width>
-							<height>36</height>
-							<aligny>center</aligny>
-							<font>font12</font>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="image">
-							<left>6</left>
-							<top>35</top>
-							<width>20</width>
-							<height>20</height>
-							<texture>$VAR[PVRTimerIcon]</texture>
-						</control>
-					</focusedlayout>
-				</control>
-				<control type="scrollbar" id="60">
-					<right>0</right>
-					<top>47</top>
-					<width>12</width>
-					<height>550</height>
-					<onleft>10</onleft>
-					<onright>10</onright>
-					<orientation>vertical</orientation>
-					<texturesliderbackground colordiffuse="22FFFFFF">colors/white.png</texturesliderbackground>
-					<animation effect="fade" start="100" end="40" time="0" condition="!system.getbool(input.enablemouse)">Conditional</animation>
+				<control type="group">
+					<depth>DepthContentPanel</depth>
+					<control type="image">
+						<left>-20</left>
+						<top>-20</top>
+						<width>1980</width>
+						<height>644</height>
+						<texture border="22">dialogs/dialog-bg.png</texture>
+					</control>
+					<control type="epggrid" id="10">
+						<left>0</left>
+						<top>0</top>
+						<width>1900</width>
+						<height>600</height>
+						<pagecontrol>60</pagecontrol>
+						<scrolltime tween="quadratic" easing="out">200</scrolltime>
+						<timeblocks>34</timeblocks>
+						<rulerunit>6</rulerunit>
+						<onleft>9000</onleft>
+						<onright>60</onright>
+						<onup>10</onup>
+						<ondown>10</ondown>
+						<viewtype label="19032">list</viewtype>
+						<progresstexture border="0,60,18,14" colordiffuse="button_focus">windows/pvr/epg_progress.png</progresstexture>
+						<rulerlayout height="45" width="1400">
+							<control type="label">
+								<width>365</width>
+								<height>45</height>
+								<font>font12</font>
+								<label>$INFO[ListItem.Label]</label>
+								<textoffsetx>10</textoffsetx>
+								<textcolor>button_focus</textcolor>
+							</control>
+						</rulerlayout>
+						<channellayout height="62" width="350">
+							<control type="label">
+								<left>2</left>
+								<top>-2</top>
+								<width>70</width>
+								<height>60</height>
+								<font>font36_title</font>
+								<label>$INFO[ListItem.ChannelNumber]</label>
+								<align>center</align>
+								<aligny>center</aligny>
+							</control>
+							<control type="label" id="1">
+								<left>65</left>
+								<top>-2</top>
+								<width>350</width>
+								<height>60</height>
+								<font>font12</font>
+								<label>$INFO[ListItem.ChannelName]</label>
+								<aligny>center</aligny>
+								<textoffsetx>10</textoffsetx>
+							</control>
+						</channellayout>
+						<focusedchannellayout height="62" width="350">
+							<control type="label">
+								<left>2</left>
+								<top>-2</top>
+								<width>70</width>
+								<height>60</height>
+								<font>font36_title</font>
+								<label>$INFO[ListItem.ChannelNumber]</label>
+								<textcolor>button_focus</textcolor>
+								<align>center</align>
+								<aligny>center</aligny>
+							</control>
+							<control type="label" id="1">
+								<left>65</left>
+								<top>-2</top>
+								<width>350</width>
+								<height>60</height>
+								<font>font12</font>
+								<label>$INFO[ListItem.ChannelName]</label>
+								<textcolor>button_focus</textcolor>
+								<aligny>center</aligny>
+								<textoffsetx>10</textoffsetx>
+							</control>
+						</focusedchannellayout>
+						<itemlayout height="62" width="60">
+							<control type="image" id="2">
+								<width>58</width>
+								<height>58</height>
+								<texture border="3" fallback="windows/pvr/epg-genres/0.png">$INFO[ListItem.Property(GenreType),windows/pvr/epg-genres/,.png]</texture>
+							</control>
+							<control type="label" id="1">
+								<left>6</left>
+								<top>0</top>
+								<width>50</width>
+								<height>36</height>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<label>$INFO[ListItem.Label]</label>
+							</control>
+							<control type="image">
+								<left>6</left>
+								<top>35</top>
+								<width>20</width>
+								<height>20</height>
+								<texture>$VAR[PVRTimerIcon]</texture>
+							</control>
+						</itemlayout>
+						<focusedlayout height="62" width="60">
+							<control type="image" id="2">
+								<top>2</top>
+								<left>2</left>
+								<width>54</width>
+								<height>54</height>
+								<texture colordiffuse="button_focus">lists/focus.png</texture>
+								<visible>Control.HasFocus(10)</visible>
+							</control>
+							<control type="image" id="2">
+								<width>58</width>
+								<height>58</height>
+								<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
+							</control>
+							<control type="image" id="2">
+								<width>58</width>
+								<height>58</height>
+								<top>0</top>
+								<texture border="3" fallback="windows/pvr/epg-genres/0.png">$INFO[ListItem.Property(GenreType),windows/pvr/epg-genres/,.png]</texture>
+								<visible>!Control.HasFocus(10)</visible>
+							</control>
+							<control type="label" id="1">
+								<left>6</left>
+								<top>0</top>
+								<width>50</width>
+								<height>36</height>
+								<aligny>center</aligny>
+								<font>font12</font>
+								<label>$INFO[ListItem.Label]</label>
+							</control>
+							<control type="image">
+								<left>6</left>
+								<top>35</top>
+								<width>20</width>
+								<height>20</height>
+								<texture>$VAR[PVRTimerIcon]</texture>
+							</control>
+						</focusedlayout>
+					</control>
+					<control type="scrollbar" id="60">
+						<right>0</right>
+						<top>47</top>
+						<width>12</width>
+						<height>550</height>
+						<onleft>10</onleft>
+						<onright>10</onright>
+						<orientation>vertical</orientation>
+						<texturesliderbackground colordiffuse="22FFFFFF">colors/white.png</texturesliderbackground>
+						<animation effect="fade" start="100" end="40" time="0" condition="!system.getbool(input.enablemouse)">Conditional</animation>
+					</control>
 				</control>
 				<control type="group">
 					<top>630</top>

--- a/1080i/MyPVRRecordings.xml
+++ b/1080i/MyPVRRecordings.xml
@@ -97,6 +97,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<left>1100</left>
 				<top>180</top>
 				<control type="image">
@@ -214,6 +215,7 @@
 				<param name="info_visible" value="true" />
 			</include>
 			<control type="group">
+				<depth>DepthBars</depth>
 				<left>1100</left>
 				<include>OpenClose_Right</include>
 				<control type="label">

--- a/1080i/MyPVRSearch.xml
+++ b/1080i/MyPVRSearch.xml
@@ -132,6 +132,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<left>1050</left>
 				<top>180</top>
 				<include>OpenClose_Right</include>

--- a/1080i/MyPVRTimers.xml
+++ b/1080i/MyPVRTimers.xml
@@ -131,6 +131,7 @@
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<left>1110</left>
 				<top>180</top>
 				<control type="image">

--- a/1080i/MyPlaylist.xml
+++ b/1080i/MyPlaylist.xml
@@ -82,47 +82,49 @@
 						</control>
 					</itemlayout>
 				</control>
-				<control type="image">
-					<left>-20</left>
-					<top>-20</top>
-					<width>442</width>
-					<height>1120</height>
-					<texture>lists/panel.png</texture>
-					<bordertexture border="20">overlays/shadow.png</bordertexture>
-					<bordersize>20</bordersize>
-				</control>
-				<control type="grouplist" id="700">
-					<orientation>vertical</orientation>
-					<itemgap>-9</itemgap>
-					<left>0</left>
-					<top>165</top>
-					<onup>700</onup>
-					<ondown>700</ondown>
-					<onleft>50</onleft>
-					<onright>50</onright>
-					<include content="PlaylistWindowButton">
-						<param name="control_id" value="20" />
-						<param name="label" value="$LOCALIZE[191]$INFO[Playlist.Random, : ]" />
-						<param name="width" value="400" />
-					</include>
-					<include content="PlaylistWindowButton">
-						<param name="control_id" value="26" />
-						<param name="label" value="" />
-						<param name="width" value="400" />
-					</include>
-					<include content="PlaylistWindowButton">
-						<param name="control_id" value="21" />
-						<param name="label" value="$LOCALIZE[190]" />
-						<param name="width" value="400" />
-					</include>
-					<include content="PlaylistWindowButton">
-						<param name="control_id" value="22" />
-						<param name="label" value="$LOCALIZE[192]" />
-						<param name="width" value="400" />
-					</include>
+				<control type="group">
+					<depth>DepthContentPanel</depth>
+					<control type="image">
+						<include>ContentPanel</include>
+						<left>-20</left>
+						<top>-20</top>
+						<width>442</width>
+						<height>1120</height>
+					</control>
+					<control type="grouplist" id="700">
+						<orientation>vertical</orientation>
+						<itemgap>-9</itemgap>
+						<left>0</left>
+						<top>165</top>
+						<onup>700</onup>
+						<ondown>700</ondown>
+						<onleft>50</onleft>
+						<onright>50</onright>
+						<include content="PlaylistWindowButton">
+							<param name="control_id" value="20" />
+							<param name="label" value="$LOCALIZE[191]$INFO[Playlist.Random, : ]" />
+							<param name="width" value="400" />
+						</include>
+						<include content="PlaylistWindowButton">
+							<param name="control_id" value="26" />
+							<param name="label" value="" />
+							<param name="width" value="400" />
+						</include>
+						<include content="PlaylistWindowButton">
+							<param name="control_id" value="21" />
+							<param name="label" value="$LOCALIZE[190]" />
+							<param name="width" value="400" />
+						</include>
+						<include content="PlaylistWindowButton">
+							<param name="control_id" value="22" />
+							<param name="label" value="$LOCALIZE[192]" />
+							<param name="width" value="400" />
+						</include>
+					</control>
 				</control>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<left>1327</left>
 				<include>OpenClose_Right</include>
 				<include content="ListThumbInfoPanel">
@@ -149,6 +151,7 @@
 		</include>
 		<include>BottomBar</include>
 		<control type="group">
+			<depth>DepthBars</depth>
 			<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 			<include>MediaFlags</include>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -18,6 +18,7 @@
 			<include>View_501_Banner</include>
 			<include>View_502_FanArt</include>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Left</include>
 				<visible>Control.IsVisible(55)</visible>
 <!-- 				<visible>Container.Content(artists) | Container.Content(albums) | Container.Content(addons) | Container.Content(files) | Container.Content(mixed) | Container.Content(musicvideos) | Container.Content(videos) | Container.Content() | Container.Content(episodes)</visible>
@@ -25,6 +26,7 @@
 				<include>ListThumbInfoPanel</include>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Left</include>
 				<visible>[Control.IsVisible(50) | Control.Isvisible(54)]</visible>
 				<include>Visible_Left</include>
@@ -171,6 +173,7 @@
 				<param name="info_visible" value="true" />
 			</include>
 			<control type="group">
+				<depth>DepthBars</depth>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<animation effect="fade" start="100" end="50" time="200" condition="$EXP[sidebar_focused]">Conditional</animation>

--- a/1080i/SettingsCategory.xml
+++ b/1080i/SettingsCategory.xml
@@ -82,6 +82,7 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="group">
+			<depth>DepthContentPanel</depth>
 			<include>OpenClose_Left</include>
 			<control type="image">
 				<left>-20</left>

--- a/1080i/SettingsProfile.xml
+++ b/1080i/SettingsProfile.xml
@@ -184,6 +184,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<depth>DepthContentPanel</depth>
 			<include>OpenClose_Left</include>
 			<control type="image">
 				<left>-20</left>

--- a/1080i/SettingsSystemInfo.xml
+++ b/1080i/SettingsSystemInfo.xml
@@ -227,6 +227,7 @@
 		<control type="group">
 			<left>0</left>
 			<top>0</top>
+			<depth>DepthContentPanel</depth>
 			<include>OpenClose_Left</include>
 			<control type="image">
 				<left>-20</left>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -189,6 +189,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<depth>DepthContentPanel</depth>
 			<left>0</left>
 			<include>OpenClose_Left</include>
 			<control type="image">

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -32,6 +32,7 @@
 			</control>
 		</control>
 		<control type="group" id="1">
+			<depth>DepthOSD+</depth>
 			<visible>Player.Caching</visible>
 			<animation delay="300" effect="fade" time="200">Visible</animation>
 			<animation effect="fade" delay="200" time="150">Hidden</animation>

--- a/1080i/View_500_Wall.xml
+++ b/1080i/View_500_Wall.xml
@@ -51,6 +51,7 @@
 						<animation effect="slide" start="0,16" end="0,0" time="200" tween="sine" easing="inout">UnFocus</animation>
 					</control>
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="160,300">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="160,300">UnFocus</animation>
 						<top>120</top>
@@ -96,6 +97,7 @@
 						<animation effect="slide" start="0,30" end="0,0" time="200" tween="sine" easing="inout">UnFocus</animation>
 					</control>
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="160,300">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="160,300">UnFocus</animation>
 						<top>150</top>
@@ -121,6 +123,7 @@
 				</itemlayout>
 				<focusedlayout height="425" width="442" condition="Container.Content(images)">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="220,330">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="220,330">UnFocus</animation>
 						<left>40</left>
@@ -146,6 +149,7 @@
 				</itemlayout>
 				<focusedlayout height="400" width="300" condition="Container.Content(artists) | Container.Content(albums) | Container.Content(musicvideos)">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<top>150</top>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="140,300">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="140,300">UnFocus</animation>
@@ -172,6 +176,7 @@
 				</itemlayout>
 				<focusedlayout height="390" width="300" condition="Container.Content(addons)">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<top>150</top>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="150,320">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="150,320">UnFocus</animation>

--- a/1080i/View_502_FanArt.xml
+++ b/1080i/View_502_FanArt.xml
@@ -17,6 +17,7 @@
 				</include>
 			</control>
 			<control type="group">
+				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Right</include>
 				<visible>Control.IsVisible(502)</visible>
 				<include>Visible_Right</include>

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -11,40 +11,44 @@
 				<param name="list_id" value="50" />
 				<param name="viewtype_label" value="$LOCALIZE[535]" />
 			</include>
-			<control type="image">
-				<left>712</left>
-				<top>-20</top>
-				<width>670</width>
-				<height>1120</height>
-				<texture>lists/panel.png</texture>
-				<bordertexture border="20">overlays/shadow.png</bordertexture>
-				<bordersize>20</bordersize>
-			</control>
-			<control type="scrollbar" id="50600">
-				<left>732</left>
-				<top>0</top>
-				<width>12</width>
-				<height>1080</height>
-				<onleft>50</onleft>
-				<onright>50</onright>
-				<orientation>vertical</orientation>
-				<animation effect="zoom" end="50,100" time="300" tween="sine" center="732,0" easing="inout" condition="!Control.HasFocus(50600)">conditional</animation>
-			</control>
-			<control type="image">
-				<left>754</left>
-				<top>140</top>
-				<width>556</width>
-				<height>836</height>
-				<fadetime>200</fadetime>
-				<aspectratio aligny="bottom">keep</aspectratio>
-				<texture fallback="DefaultVideo.png" background="true">$VAR[InfoWallThumbVar]</texture>
-			</control>
 			<control type="group">
-				<left>1013</left>
-				<top>950</top>
-				<include content="UserRatingCircle">
-					<param name="animation" value="True" />
-				</include>
+				<depth>DepthContentPanel</depth>
+				<control type="image">
+					<left>712</left>
+					<top>-20</top>
+					<width>670</width>
+					<height>1120</height>
+					<texture>lists/panel.png</texture>
+					<bordertexture border="20">overlays/shadow.png</bordertexture>
+					<bordersize>20</bordersize>
+				</control>
+				<control type="scrollbar" id="50600">
+					<left>732</left>
+					<top>0</top>
+					<width>12</width>
+					<height>1080</height>
+					<onleft>50</onleft>
+					<onright>50</onright>
+					<orientation>vertical</orientation>
+					<animation effect="zoom" end="50,100" time="300" tween="sine" center="732,0" easing="inout" condition="!Control.HasFocus(50600)">conditional</animation>
+				</control>
+				<control type="image">
+					<depth>DepthContentPopout</depth>
+					<left>754</left>
+					<top>140</top>
+					<width>556</width>
+					<height>836</height>
+					<fadetime>200</fadetime>
+					<aspectratio aligny="bottom">keep</aspectratio>
+					<texture fallback="DefaultVideo.png" background="true">$VAR[InfoWallThumbVar]</texture>
+				</control>
+				<control type="group">
+					<left>1013</left>
+					<top>950</top>
+					<include content="UserRatingCircle">
+						<param name="animation" value="True" />
+					</include>
+				</control>
 			</control>
 		</control>
 	</include>
@@ -152,14 +156,49 @@
 	<include name="ListThumbInfoPanel">
 		<param name="flip_bg">false</param>
 		<definition>
-			<control type="image">
-				<left>-20</left>
-				<top>-20</top>
-				<width>634</width>
-				<height>1120</height>
-				<texture>lists/panel.png</texture>
-				<bordertexture border="20">overlays/shadow.png</bordertexture>
-				<bordersize>20</bordersize>
+			<control type="group">
+				<depth>DepthContentPanel</depth>
+				<control type="image">
+					<left>-20</left>
+					<top>-20</top>
+					<width>634</width>
+					<height>1120</height>
+					<texture>lists/panel.png</texture>
+					<bordertexture border="20">overlays/shadow.png</bordertexture>
+					<bordersize>20</bordersize>
+				</control>
+				<control type="image">
+					<left>60</left>
+					<top>140</top>
+					<width>470</width>
+					<height>470</height>
+					<aspectratio aligny="bottom">keep</aspectratio>
+					<fadetime>300</fadetime>
+					<texture background="true">$VAR[IconWallThumbVar]</texture>
+				</control>
+				<control type="textbox" id="15500">
+					<left>30</left>
+					<top>640</top>
+					<width>525</width>
+					<height>323</height>
+					<font>font13</font>
+					<autoscroll time="3000" delay="7000" repeat="5000">!System.HasModalDialog + Skin.HasSetting(AutoScroll)</autoscroll>
+					<label>$VAR[ListBoxInfoVar]</label>
+					<visible>!Container.Content() | !IsEmpty(ListItem.Plot)</visible>
+				</control>
+				<control type="textbox">
+					<left>30</left>
+					<top>460</top>
+					<width>530</width>
+					<height>413</height>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font27</font>
+					<textcolor>80FFFFFF</textcolor>
+					<label>$LOCALIZE[19055]</label>
+					<visible>!ListItem.IsParentFolder</visible>
+					<visible>String.IsEmpty(Control.GetLabel(15500)) + [!Container.Content() | !IsEmpty(ListItem.Plot)]</visible>
+				</control>
 			</control>
 			<control type="image">
 				<left>30</left>

--- a/1080i/View_51_Poster.xml
+++ b/1080i/View_51_Poster.xml
@@ -172,6 +172,7 @@
 		<control type="group">
 			<top>205</top>
 			<left>101</left>
+			<depth>DepthContentPopout</depth>
 			<visible>Control.IsVisible(51)</visible>
 			<include>OpenClose_Left</include>
 			<include>Visible_Left</include>

--- a/1080i/View_52_IconWall.xml
+++ b/1080i/View_52_IconWall.xml
@@ -154,6 +154,7 @@
 				</itemlayout>
 				<focusedlayout height="181" width="348" condition="Container.Content(genres) | Container.Content(years) | Container.Content(roles) | Container.Content(countries) | [Container.Content(studios) + !System.HasAddon(resource.images.studios.white)]">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<top>120</top>
 						<animation type="Focus" reversible="false">
 							<effect type="zoom" center="auto" start="100" end="108" time="250" tween="sine" />

--- a/1080i/View_53_Shift.xml
+++ b/1080i/View_53_Shift.xml
@@ -63,6 +63,7 @@
 					<viewtype label="31100">icon</viewtype>
 					<itemlayout width="370">
 						<control type="image">
+							<depth>DepthContentPopout</depth>
 							<left>0</left>
 							<top>90</top>
 							<width>370</width>
@@ -94,6 +95,7 @@
 						<control type="group">
 							<left>0</left>
 							<control type="image">
+								<depth>DepthContentPopout</depth>
 								<left>0</left>
 								<top>90</top>
 								<width>370</width>

--- a/1080i/View_54_InfoWall.xml
+++ b/1080i/View_54_InfoWall.xml
@@ -167,6 +167,7 @@
 				</itemlayout>
 				<focusedlayout height="445" width="320" condition="Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)">
 					<control type="image">
+					
 						<left>224</left>
 						<top>498</top>
 						<width>32</width>
@@ -176,6 +177,7 @@
 						<animation effect="slide" start="0,16" end="0,0" time="200" tween="sine" easing="inout">UnFocus</animation>
 					</control>
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<left>80</left>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="240,300">Focus</animation>
 						<animation effect="zoom" start="110" end="100" time="200" tween="sine" easing="inout" center="240,300">UnFocus</animation>
@@ -210,6 +212,7 @@
 				</itemlayout>
 				<focusedlayout height="410" width="310" condition="Container.Content(artists) | Container.Content(albums) | Container.Content(musicvideos)">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<animation effect="zoom" start="100" end="115" time="200" tween="sine" easing="inout" center="250,330">Focus</animation>
 						<animation effect="zoom" start="115" end="100" time="200" tween="sine" easing="inout" center="250,330">UnFocus</animation>
 						<top>150</top>
@@ -239,6 +242,7 @@
 				</itemlayout>
 				<focusedlayout height="400" width="401" condition="Container.Content(images)">
 					<control type="group">
+						<depth>DepthContentPopout</depth>
 						<left>30</left>
 						<top>150</top>
 						<animation effect="zoom" start="100" end="110" time="200" tween="sine" easing="inout" center="220,330">Focus</animation>


### PR DESCRIPTION
as title says. I had to add a slightly bigger offset on some of the textures to get rid of glitches on screen edges in 3D mode. I likely missed some of these glitches, but they can be fixed once identified.