### PR TITLE
keep a dimmed focus state on list menus

### DIFF
--- a/1080i/Custom_1100_AddonLauncher.xml
+++ b/1080i/Custom_1100_AddonLauncher.xml
@@ -92,6 +92,15 @@
 					<onright>SetFocus($INFO[Container(9000).ListItem.Property(menu_id)])</onright>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
 					<focusedlayout height="95">
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<width>462</width>
+							<height>95</height>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<animation effect="fade" start="100" end="0" time="0">Focus</animation>
+							<animation effect="fade" start="0" end="50" time="0">UnFocus</animation>
+						</control>
 						<control type="group">
 							<animation effect="fade" start="100" end="0" time="0">UnFocus</animation>
 							<control type="image">

--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -937,6 +937,15 @@
 					<ondown>noop</ondown>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
 					<focusedlayout height="95">
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<width>462</width>
+							<height>95</height>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<animation effect="fade" start="100" end="0" time="0">Focus</animation>
+							<animation effect="fade" start="0" end="50" time="0">UnFocus</animation>
+						</control>
 						<control type="group">
 							<animation effect="fade" start="100" end="0" time="0">UnFocus</animation>
 							<control type="image">
@@ -1149,7 +1158,7 @@
 						<aspectratio>keep</aspectratio>
 						<width>56</width>
 						<height>56</height>
-						<texture colordiffuse="button_focus">icons/logo.png</texture>
+						<texture colordiffuse="logo">icons/logo.png</texture>
 					</control>
 					<control type="image">
 						<left>40</left>
@@ -1157,7 +1166,7 @@
 						<aspectratio>keep</aspectratio>
 						<width>192</width>
 						<height>36</height>
-						<texture>icons/logo-text.png</texture>
+						<texture colordiffuse="text">icons/logo-text.png</texture>
 					</control>
 				</control>
 			</control>
@@ -1176,7 +1185,7 @@
 					<titlecolor>button_focus</titlecolor>
 					<shadowcolor>text_shadow</shadowcolor>
 					<headlinecolor>FFC0C0C0</headlinecolor>
-					<textcolor>white</textcolor>
+					<textcolor>text</textcolor>
 					<visible>!Player.hasMedia</visible>
 				</control>
 			</control>

--- a/1080i/View_50_List.xml
+++ b/1080i/View_50_List.xml
@@ -77,6 +77,15 @@
 					<width>list_width</width>
 					<height>69</height>
 					<texture colordiffuse="button_focus">lists/focus.png</texture>
+					<animation effect="fade" start="100" end="0" time="0">Focus</animation>
+					<animation effect="fade" start="0" end="50" time="0">UnFocus</animation>
+				</control>
+				<control type="image">
+					<left>0</left>
+					<top>0</top>
+					<width>list_width</width>
+					<height>69</height>
+					<texture colordiffuse="button_focus">lists/focus.png</texture>
 					<visible>Control.HasFocus($PARAM[list_id])</visible>
 				</control>
 				<control type="label">

--- a/1080i/View_55_WideList.xml
+++ b/1080i/View_55_WideList.xml
@@ -28,6 +28,15 @@
 						<width>widelist_width</width>
 						<height>80</height>
 						<texture colordiffuse="button_focus">lists/focus.png</texture>
+						<animation effect="fade" start="100" end="0" time="0">Focus</animation>
+						<animation effect="fade" start="0" end="50" time="0">UnFocus</animation>
+					</control>
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>widelist_width</width>
+						<height>80</height>
+						<texture colordiffuse="button_focus">lists/focus.png</texture>
 						<visible>Control.HasFocus(55)</visible>
 					</control>
 					<control type="label">


### PR DESCRIPTION
Settings screens keep a dimmed focus state on on menu entries. Align other lists and menus to same behavior, which IMO improves especially home menu and add-on launcher