### PR TITLE
make DialogSeekBar.xml visible only when the MusicInfo is explicitly requested

### DIFF
--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<visible>[[Player.Seeking | Player.DisplayAfterSeek | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Window.IsActive(fullscreeninfo) | Window.IsActive(videoosd) | Window.IsActive(playerprocessinfo)] + Window.IsActive(fullscreenvideo)] | Window.IsActive(visualisation) | !IsEmpty(Player.SeekNumeric)</visible>
+	<visible>[[Player.Seeking | Player.DisplayAfterSeek | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Window.IsActive(fullscreeninfo) | Window.IsActive(videoosd) | Window.IsActive(playerprocessinfo)] + Window.IsActive(fullscreenvideo)] | Player.ShowInfo + Window.IsActive(visualisation) | Window.IsActive(musicosd) | !IsEmpty(Player.SeekNumeric)</visible>
 	<visible>!Window.IsActive(sliderdialog)</visible>
 	<include>Animation_BottomSlide</include>
 	<depth>DepthOSD</depth>


### PR DESCRIPTION
changed the condition to display the DialogSeekBar.xml during music fullscreen playback to display it only when the MusicInfo is explicitly requested. Custom_1109_TopBarOverlay.xml will follow this rule and so remains untouched.