### PR TITLE
Don't close MovieInformation dialog before launching CinemaVision - allow the add-on to do it

### DIFF
--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -405,8 +405,7 @@
 					<include content="InfoDialogButton">
 						<param name="id" value="441" />
 						<param name="icon" value="icons/infodialogs/cinema.png" />
-						<param name="onclick_1" value="Dialog.Close(MovieInformation)" />
-						<param name="onclick_2" value="RunScript(script.cinemavision,experience)" />
+						<param name="onclick_1" value="RunScript(script.cinemavision,dbtype=$INFO[ListItem.DBType],dbid=$INFO[ListItem.DBID])" />
 						<param name="label" value="$LOCALIZE[31003]" />
 						<param name="visible" value="System.HasAddon(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
 					</include>


### PR DESCRIPTION
When the dialog is opened from the _home window widgets_ and then closed before the add-on launches, there is no list item info available to the add-on.

This PR leaves the window open, so the add-on can close it after getting the info. It has the added benefit of providing the likely user expected behavior of returning to the info dialog if the add-on dialog is canceled.

If for some reason this solution does not make sense, an alternative would be to pass `ListItem.DBType` and `ListItem.DBID` to the add-on. I'm of course open to any other suggestions as well.

Note: sys.listitem (as you've suggested in the past) does not work here (AttributeError) and hasn't worked for me yet. Perhaps it doesn't work for script add-ons?

Thanks!