### PR TITLE
Improvements to music visualization using just artwork

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -694,8 +694,14 @@ msgctxt "#31162"
 msgid "Play your personal games or download one of the many game add-ons from the official repository."
 msgstr ""
 
+#. Label of a setting
 #: /xml/Custom_1105_MusicOSDSettings.xml
 msgctxt "#31163"
 msgid "Show Fanart background"
 msgstr ""
 
+#. Label of a setting
+#: /xml/SkinSettings.xml
+msgctxt "#31164"
+msgid "Animate background"
+msgstr ""

--- a/xml/Custom_1105_MusicOSDSettings.xml
+++ b/xml/Custom_1105_MusicOSDSettings.xml
@@ -31,6 +31,12 @@
 						<onclick>Skin.ToggleSetting(hide_background_fanart)</onclick>
 						<selected>!Skin.HasSetting(hide_background_fanart)</selected>
 					</control>
+					<control type="radiobutton" id="606">
+						<label>$LOCALIZE[31164]</label>
+						<include>DialogSettingButton</include>
+						<onclick>Skin.ToggleSetting(animate_background_fanart)</onclick>
+						<selected>Skin.HasSetting(animate_background_fanart)</selected>
+					</control>
 					<control type="button" id="5002">
 						<width>600</width>
 						<include>DialogSettingButton</include>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -19,7 +19,7 @@
 				<fadetime>400</fadetime>
 				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
-			<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+				<texture background="true" colordiffuse="88FFFFFF" fallback="$INFO[Player.Art(thumb)]">$INFO[Player.Art(fanart)]</texture>
 			</control>
 			<control type="multiimage">
 				<aspectratio>scale</aspectratio>
@@ -32,7 +32,7 @@
 			</control>
 		</control>
 		<control type="group">
-			<animation effect="fade" start="100" end="30" time="0" condition="!Skin.HasSetting(hide_background_fanart) + [!String.IsEmpty(Player.Art(fanart)) | Visualisation.Enabled | System.HasAddon(script.artistslideshow)]">Conditional</animation>
+			<animation effect="fade" start="100" end="30" time="0" condition="!Skin.HasSetting(hide_background_fanart) + [!String.IsEmpty(Player.Art(fanart)) | !String.IsEmpty(Player.Art(thumb)) | Visualisation.Enabled | System.HasAddon(script.artistslideshow)]">Conditional</animation>
 			<include>ColoredBackgroundImages</include>
 		</control>
 		<control type="group">

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -2,25 +2,37 @@
 <window>
 	<defaultcontrol></defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
+	<onload condition="System.HasAddon(script.artistslideshow) + !Skin.HasSetting(hide_background_fanart)">RunScript(script.artistslideshow)</onload>
 	<controls>
 		<control type="visualisation">
 			<include>FullScreenDimensions</include>
 			<visible>Player.HasAudio</visible>
 		</control>
-		<control type="image">
-			<left>0</left>
-			<top>0</top>
-			<width>100%</width>
-			<height>100%</height>
-			<aspectratio>scale</aspectratio>
-			<fadetime>400</fadetime>
-			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
-			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
-			<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+		<control type="group">
+			<depth>DepthBackground</depth>
+			<include>FullScreenDimensions</include>
 			<visible>!Skin.HasSetting(hide_background_fanart)</visible>
+			<animation effect="zoom" start="105" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
+			<animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
+			<control type="image">
+				<aspectratio>scale</aspectratio>
+				<fadetime>400</fadetime>
+				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+			<texture background="true" colordiffuse="88FFFFFF">$INFO[Player.Art(fanart)]</texture>
+			</control>
+			<control type="multiimage">
+				<aspectratio>scale</aspectratio>
+				<timeperimage>10000</timeperimage>
+				<randomize>true</randomize>
+				<fadetime>600</fadetime>
+				<loop>yes</loop>
+				<imagepath background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow)]</imagepath>
+				<visible>System.HasAddon(script.artistslideshow)</visible>
+			</control>
 		</control>
 		<control type="group">
-			<animation effect="fade" start="100" end="30" time="0" condition="!String.IsEmpty(Player.Art(fanart)) | Visualisation.Enabled">Conditional</animation>
+			<animation effect="fade" start="100" end="30" time="0" condition="!Skin.HasSetting(hide_background_fanart) + [!String.IsEmpty(Player.Art(fanart)) | Visualisation.Enabled | System.HasAddon(script.artistslideshow)]">Conditional</animation>
 			<include>ColoredBackgroundImages</include>
 		</control>
 		<control type="group">


### PR DESCRIPTION
This adds support for the artistslideshow addon. In addition it fixes 3D depths of the viz background. Can remove the later change if desired.

I'd like to add a setting that allows to animate the slideshow in the background, wasn't sure though where to place it best and how to do this correctly. Suggestions welcome.