### PR TITLE
show chinese input labels in proper position

### DIFF
--- a/xml/DialogKeyboard.xml
+++ b/xml/DialogKeyboard.xml
@@ -614,8 +614,8 @@
 				<content>$VAR[AutoCompletionContentVar]</content>
 			</control>
 			<control type="label" id="313">
-				<left>60</left>
-				<top>690</top>
+				<centerleft>50%</centerleft>
+				<top>290</top>
 				<width>1480</width>
 				<height>90</height>
 				<font>font37</font>
@@ -625,22 +625,22 @@
 			<control type="group">
 				<visible>Control.IsVisible(313)</visible>
 				<control type="image">
-					<left>20</left>
-					<top>690</top>
+					<centerleft>50%</centerleft>
+					<top>290</top>
 					<width>1560</width>
 					<height>90</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="image">
-					<left>20</left>
-					<top>770</top>
+					<centerleft>50%</centerleft>
+					<top>370</top>
 					<width>1560</width>
 					<height>90</height>
 					<texture border="40">buttons/dialogbutton-nofo.png</texture>
 				</control>
 				<control type="label" id="314">
-					<left>60</left>
-					<top>770</top>
+					<centerleft>50%</centerleft>
+					<top>370</top>
 					<width>1480</width>
 					<height>90</height>
 					<font>font37</font>


### PR DESCRIPTION
For now, Chinese input labels overlap with the visual keyboard. this PR fixed the issue.

screenshot after fixed:
![screenshot019](https://cloud.githubusercontent.com/assets/102434/23013751/f053a866-f466-11e6-81e8-49d833bcf234.png)
