### PR TITLE
use Player.Title instead of Filename for subtitle dialog

### DIFF
--- a/xml/DialogSubtitles.xml
+++ b/xml/DialogSubtitles.xml
@@ -77,7 +77,7 @@
 					<width>920</width>
 					<height>30</height>
 					<font>font30_title</font>
-					<label>$INFO[Player.Filename]</label>
+					<label>$INFO[Player.Title]</label>
 					<align>center</align>
 					<aligny>center</aligny>
 					<textcolor>grey</textcolor>


### PR DESCRIPTION
The filename might be something completely irrelevant, e.g. an internal id of a streaming service. The Title should always provide something meaningful.