### PR TITLE
DialogPVRChannelsOSD elements missing from on screen display (to krypton)

### DIFF
--- a/xml/DialogPVRChannelsOSD.xml
+++ b/xml/DialogPVRChannelsOSD.xml
@@ -22,7 +22,7 @@
 					<movement>4</movement>
 					<focusposition>5</focusposition>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
-					<focusedlayout height="90" width="1000">
+					<focusedlayout height="90" width="875">
 						<control type="image">
 							<left>0</left>
 							<right>0</right>
@@ -31,45 +31,45 @@
 							<visible>Control.hasFocus(11)</visible>
 						</control>
 						<control type="image">
-							<left>770</left>
+							<right>20</right>
 							<top>10</top>
-							<width>90</width>
-							<bottom>10</bottom>
+							<width>80</width>
+							<height>70</height>
 							<aspectratio align="right">keep</aspectratio>
 							<texture>$INFO[listitem.icon]</texture>
 						</control>
 						<control type="progress">
 							<left>105</left>
-							<top>55</top>
+							<top>58</top>
 							<width>50</width>
 							<height>12</height>
 							<midtexture border="3">progress/texturebg_white.png</midtexture>
-							<visible>ListItem.HasEpg + !ListItem.IsRecording</visible>
+							<visible>ListItem.HasEpg</visible>
 							<info>ListItem.Progress</info>
 						</control>
 						<control type="image">
-							<right>15</right>
-							<top>9</top>
+							<right>110</right>
+							<top>25</top>
 							<width>40</width>
 							<height>40</height>
 							<texture>$VAR[PVRStatusImageVar]</texture>
 						</control>
 						<control type="label">
 							<left>105</left>
-							<top>5</top>
+							<top>8</top>
 							<height>90</height>
-							<width>600</width>
+							<right>120</right>
 							<aligny>top</aligny>
-							<animation effect="slide" start="0,0" end="0,18" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<label>$INFO[ListItem.Label]</label>
 							<font>font14</font>
+							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
+							<label>$INFO[ListItem.Label]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 						<control type="label">
 							<left>165</left>
-							<top>45</top>
+							<top>46</top>
 							<height>90</height>
-							<width>580</width>
+							<right>120</right>
 							<aligny>top</aligny>
 							<font>font12</font>
 							<label>$INFO[ListItem.Title]</label>
@@ -77,6 +77,7 @@
 						</control>
 						<control type="label">
 							<left>12</left>
+							<top>0</top>
 							<height>90</height>
 							<width>75</width>
 							<align>center</align>
@@ -86,47 +87,47 @@
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</focusedlayout>
-					<itemlayout height="90">
+					<itemlayout height="90" width="875">
 						<control type="image">
-							<left>770</left>
+							<right>20</right>
 							<top>10</top>
-							<width>90</width>
-							<bottom>10</bottom>
+							<width>80</width>
+							<height>70</height>
 							<aspectratio align="right">keep</aspectratio>
 							<texture>$INFO[listitem.icon]</texture>
 						</control>
 						<control type="progress">
 							<left>105</left>
-							<top>55</top>
+							<top>58</top>
 							<width>50</width>
 							<height>12</height>
 							<colordiffuse>88FFFFFF</colordiffuse>
-							<visible>ListItem.HasEpg + !ListItem.IsRecording</visible>
+							<visible>ListItem.HasEpg</visible>
 							<info>ListItem.Progress</info>
 						</control>
 						<control type="image">
-							<right>15</right>
-							<top>9</top>
+							<right>110</right>
+							<top>25</top>
 							<width>40</width>
 							<height>40</height>
 							<texture>$VAR[PVRStatusImageVar]</texture>
 						</control>
 						<control type="label">
 							<left>105</left>
-							<top>5</top>
+							<top>8</top>
 							<height>90</height>
-							<width>640</width>
+							<right>120</right>
 							<aligny>top</aligny>
-							<label>$INFO[ListItem.Label]</label>
 							<font>font14</font>
-							<animation effect="slide" start="0,0" end="0,18" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
+							<label>$INFO[ListItem.Label]</label>
+							<animation effect="slide" start="0,0" end="0,14" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 						<control type="label">
 							<left>165</left>
-							<top>45</top>
+							<top>46</top>
 							<height>90</height>
-							<width>580</width>
+							<right>120</right>
 							<aligny>top</aligny>
 							<font>font12</font>
 							<label>$INFO[ListItem.Title]</label>
@@ -135,6 +136,7 @@
 						</control>
 						<control type="label">
 							<left>12</left>
+							<top>0</top>
 							<height>90</height>
 							<width>75</width>
 							<align>center</align>
@@ -147,7 +149,7 @@
 					</itemlayout>
 				</control>
 				<control type="scrollbar" id="60">
-					<left>868</left>
+					<left>869</left>
 					<width>12</width>
 					<height>100%</height>
 					<onleft>11</onleft>


### PR DESCRIPTION
The progress bar and recording icon are not visible in the Live TV on
screen channel display for a channel which is currently being recorded.

Suggest copying the focussed and item layouts completely (for easier
future maintenance) from MyPVRChannels and adjusting the widths
accordingly. The scrollbar position then also needs a slight adjustment.