### PR TITLE
Only show repository for installed addons

### DIFF
--- a/xml/DialogAddonInfo.xml
+++ b/xml/DialogAddonInfo.xml
@@ -249,7 +249,7 @@
 						<width>470</width>
 						<height>40</height>
 						<label>$INFO[ListItem.AddonOrigin,[COLOR button_focus]$LOCALIZE[31150]:[/COLOR] ]</label>
-						<visible>!String.IsEmpty(ListItem.AddonOrigin)</visible>
+						<visible>!String.IsEmpty(ListItem.AddonOrigin) + ListItem.Property(addon.isinstalled)</visible>
 					</control>
 				</control>
 			</control>


### PR DESCRIPTION
As kodi doesn't fill addonOrigin when you browse a repository it's always `Unknown` in that case. I feel like it's a bit confusing, so this hides the field when browsing a repository.