### PR TITLE
Display PVR Year field.

### DIFF
--- a/xml/DialogPVRInfo.xml
+++ b/xml/DialogPVRInfo.xml
@@ -105,7 +105,7 @@
 				</control>
 			</control>
 			<include content="InfoDialogTopBarInfo">
-				<param name="main_label" value="$INFO[ListItem.Title]$INFO[ListItem.Season, ]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR]]" />
+				<param name="main_label" value="$INFO[ListItem.Title]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]$INFO[ListItem.Season, ]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR]]" />
 				<param name="sub_label" value="$INFO[ListItem.ChannelName]" />
 				<param name="posy" value="40" />
 			</include>

--- a/xml/MyPVRGuide.xml
+++ b/xml/MyPVRGuide.xml
@@ -65,7 +65,7 @@
 						<right>60</right>
 						<height>30</height>
 						<textcolor>button_focus</textcolor>
-						<label>$INFO[ListItem.StartTime,, - ]$INFO[ListItem.EndTime]$INFO[ListItem.EpgEventTitle,  [COLOR white],[/COLOR]]$INFO[ListItem.EpisodeName, [COLOR grey](,)[/COLOR]]$INFO[ListItem.Genre,      $LOCALIZE[515]: [COLOR grey],[/COLOR]]</label>
+						<label>$INFO[ListItem.StartTime,, - ]$INFO[ListItem.EndTime]$INFO[ListItem.EpgEventTitle,  [COLOR white],[/COLOR]]$INFO[ListItem.Year, [COLOR grey](,)[/COLOR]]$INFO[ListItem.EpisodeName, [COLOR grey](,)[/COLOR]]$INFO[ListItem.Genre,      $LOCALIZE[515]: [COLOR grey],[/COLOR]]</label>
 					</control>
 					<control type="textbox">
 						<left>300</left>


### PR DESCRIPTION
My PVR passes through the year for movies so I've added the displaying of the year to the PVR guide and PVR info immediately after the title so it is shown as "Film (1999)".

I'm sorry I could not work out how to add it to MyPVRSearch.xml nor to MyPVRChannels.xml. The later has a "[CR]" in the $INFO and I could not find an example of how to get the (optional) year to be appended to the title and before the CR.

I have no problems at all if the patch is rejected or modified in favour of a better approach.