### PR TITLE
Add Music Graphical Star User Ratings to WideList view

### DIFF
--- a/xml/View_55_WideList.xml
+++ b/xml/View_55_WideList.xml
@@ -227,6 +227,16 @@
 				<label>$INFO[ListItem.Label2]</label>
 				<shadowcolor>text_shadow</shadowcolor>
 			</control>
+			<control type="image">
+				<left>900</left>
+				<height>32</height>
+				<right>0</right>
+				<top>24</top>
+				<align>right</align>
+				<aligny>center</aligny>
+				<aspectratio>keep</aspectratio>
+				<texture>$INFO[ListItem.UserRating,flags/starrating/,.png]</texture>
+			</control>
 		</focusedlayout>
 		<itemlayout height="80" condition="Container.Content(songs)">
 			<control type="label">
@@ -246,6 +256,16 @@
 				<label>$INFO[ListItem.Label2]</label>
 				<textcolor>grey</textcolor>
 				<shadowcolor>text_shadow</shadowcolor>
+			</control>
+			<control type="image">
+				<left>900</left>
+				<height>32</height>
+				<right>0</right>
+				<top>24</top>
+				<align>right</align>
+				<aligny>center</aligny>
+				<aspectratio>keep</aspectratio>
+				<texture>$INFO[ListItem.UserRating,flags/starrating/,.png]</texture>
 			</control>
 		</itemlayout>
 	</include>


### PR DESCRIPTION
Simple addition to add the Wide List view to show the User Rating as stars when browsing an album.

While its nice to have the option to enable/disable the user rating or overall rating for all media types, music is slightly different, as it is preferable to show all the ratings on one screen (so you can see the best songs in the track list). The ratings only show if the user has actually rated tracks so most users will not see a difference until they use this feature.

It should also compliment the current rating stars on the album artwork as they show the numerical value which is useful in addition to stars.

Hopefully I got the alignment values correct... Tested on my 1080p windows dev machine, and Nvidia shield @ 4k

![screenshot000](https://user-images.githubusercontent.com/1050512/32751678-9fad7c98-c8be-11e7-83fb-40786a12d336.png)

iTunes uses the same kind of feature in its music list views, so its a common feature in other apps:

![itunes-half-rating](https://user-images.githubusercontent.com/1050512/32751750-ca15936c-c8be-11e7-8b24-f643efc48b55.jpg)

Code originally came from Aeon Nox 5, so thanks @BigNoid 