### PR TITLE
fix for #254 - missing variable for year/rating sorting;

### DIFF
--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -80,6 +80,8 @@
 		<value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
 		<value condition="String.IsEqual(Container.SortMethod,$LOCALIZE[556])">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
+		<value condition="Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[562])">$INFO[ListItem.Year]</value>
+		<value condition="Container.Content(tvshows) + String.IsEqual(Container.SortMethod,$LOCALIZE[563])">$INFO[ListItem.Rating]</value>
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
 	<variable name="ShiftLeftTextBoxVar">


### PR DESCRIPTION
This fix add two variables that check if content is `tvshow` and check if sorting is set to `year` or `rating` and fill the variable with year or rating currently.