### PR TITLE
Show Studio icons (e.g. on folders and episodes)

### DIFF
--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -399,7 +399,7 @@
 				<control type="group">
 					<width>150</width>
 					<top>-5</top>
-					<visible>String.IsEqual($PARAM[infolabel_prefix]ListItem.DBtype,tvshow)</visible>
+					<visible>System.HasAddon(resource.images.studios.white) + !String.IsEmpty($PARAM[infolabel_prefix]ListItem.Studio)</visible>
 					<include content="MediaFlag">
 						<param name="texture" value="$INFO[$PARAM[infolabel_prefix]ListItem.Studio,resource://resource.images.studios.white/,.png]" />
 					</include>


### PR DESCRIPTION
So rather than limiting the skin to show Studio icons on a tvshow only, we would like to see the studio icons on episodes and folders too. If the ListItem has the studio infolabel set, we use it.

This fixes pietje666/plugin.video.vrt.nu#250